### PR TITLE
Make it easier to start span with a trace id

### DIFF
--- a/jot/facade.py
+++ b/jot/facade.py
@@ -57,12 +57,8 @@ def count(*args, **kwargs):
 
 
 @_contextmanager
-def span(name, trace_id=None, parent_id=None, **tags):
-    if trace_id is None:
-        child = active.start(name, **tags)
-    else:
-        span = active.target.span(trace_id=trace_id, parent_id=parent_id, name=name)
-        child = Telemeter(active.target, span, **tags)
+def span(name, dtags={}, trace_id=None, parent_id=None, **kwtags):
+    child = active.start(name, dtags, trace_id, parent_id, **kwtags)
     _push(child)
 
     try:

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -49,7 +49,7 @@ def test_start_root():
 def test_start_child():
     parent = Span(1, 2, 3, "parent")
     target = Target()
-    child = target.start(parent, "child")
+    child = target.start(parent.trace_id, parent.id, name="child")
     assert child.trace_id == parent.trace_id
     assert child.parent_id == parent.id
     assert isinstance(child.id, bytes)

--- a/tests/test_telemeter.py
+++ b/tests/test_telemeter.py
@@ -73,6 +73,25 @@ def test_start_tags(jot, dtags, kwtags, assert_tags_are_correct):
     assert_tags_are_correct(child)
 
 
+def test_start_trace_id(jot):
+    trace_id = Span.gen_trace_id()
+    child = jot.start("child", trace_id=trace_id)
+    assert child.span.trace_id == trace_id
+    assert child.span.parent_id is None
+    assert isinstance(child.span.id, bytes)
+    assert child.span.name == "child"
+
+def test_start_parent_id(jot):
+    trace_id = Span.gen_trace_id()
+    parent_id = Span.gen_span_id()
+    child = jot.start("child", trace_id=trace_id, parent_id=parent_id)
+    assert child.span.trace_id == trace_id
+    assert child.span.parent_id is parent_id
+    assert isinstance(child.span.id, bytes)
+    assert child.span.name == "child"
+
+
+
 def test_finish(jot, mocker):
     sspy = mocker.spy(jot.span, "finish")
     tspy = mocker.spy(jot.target, "finish")

--- a/tests/test_zipkin.py
+++ b/tests/test_zipkin.py
@@ -17,21 +17,21 @@ def test_start_root():
 def test_start_child():
     target = ZipkinTarget(None)
     root = target.start()
-    span = target.start(root)
+    span = target.start(root.trace_id, root.id, name="span")
     check_ids(span)
     assert span.parent_id == root.id
 
 
 def test_start_name():
     target = ZipkinTarget(None)
-    span = target.start(None, "root span")
+    span = target.start(name="root span")
     assert span.name == "root span"
 
 
 def test_finish(requests_mock):
     target = ZipkinTarget("http://example.com/post")
     root = target.start()
-    span = target.start(root, "test-span")
+    span = target.start(root.trace_id, root.id, name="test-span")
     target.event("an event", {}, span)
     tags = {
         "pluff": 667,


### PR DESCRIPTION
This helps the common case where a span is created using a trace ID and parent span ID that were unpacked from some transport mechanism in a distributed trace.